### PR TITLE
Resync Transactions

### DIFF
--- a/app/Console/Commands/ReSyncTransactions.php
+++ b/app/Console/Commands/ReSyncTransactions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Setting;
+use App\Transaction;
+use Illuminate\Console\Command;
+use App\Http\Controllers\CommonController;
+
+class ReSyncTransactions extends Command
+{
+    protected $signature = 'resync:transactions';
+    protected $description = 'Resync Transactions';
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $body = [
+            'terminal_signature' => Setting::find(1)->value
+        ];
+
+        $server = CommonController::curl(config('app.ecoi_server_url').'/api/cancelled-transactions', 'post', $body);
+
+        if(isset($server->status_code)){
+            if($server->status_code == 200 && isset($server->data)) {
+                Transaction::whereIn('coi_number', $server->data)
+                    ->where('status', '!=', 'deleted')
+                    ->update([
+                        'uploaded' => false,
+                    ]);
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,20 +2,21 @@
 
 namespace App\Http\Controllers\Auth;
 
+use DB;
+use Auth;
+use App\Menu;
+use App\User;
+use App\Setting;
+use App\UserRole;
+
+use Carbon\Carbon;
+use App\Transaction;
+use App\Insuran_price;
+use Illuminate\Support\Str;
+use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\CommonController;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
-use Illuminate\Http\Request;
-use Illuminate\Support\Str;
-use Carbon\Carbon;
-
-use App\User;
-use App\Menu;
-use App\UserRole;
-use App\Setting;
-use App\Insuran_price;
-use DB;
-use Auth;
 
 class LoginController extends Controller
 {
@@ -51,6 +52,25 @@ class LoginController extends Controller
 
     public function login(Request $request)
     {
+        $user_id = User::where('username', $request->username)->first()->id;
+        // $latest_transaction = Transaction::select('date_issued')
+        //     ->where('userid_created', $user_id)
+        //     ->where('posted', false)
+        //     ->where('status', '!=', 'deleted')
+        //     ->orderBy('date_issued', 'desc')
+        //     ->first()
+        //     ->date_issued;
+
+        // if(Carbon::parse($latest_transaction)->lt(Carbon::today())){
+            Transaction::where('posted', false)
+                ->whereDate('date_issued', '<', Carbon::today()->format('Y-m-d'))
+                ->where('userid_created', $user_id)
+                ->where('status', '!=', 'deleted')
+                ->update([
+                    'status' => 'deleted'
+                ]);
+        // }
+
         if(Auth::attempt([
             'username' => $request->username,
             'password' => $request->password

--- a/app/Http/Middleware/SyncTransactions.php
+++ b/app/Http/Middleware/SyncTransactions.php
@@ -24,10 +24,20 @@ class SyncTransactions
 
             $terminal_signature = session('terminalSignature');
     
+            $uploaded = [];
             foreach($transactions as $transaction) {
                 $transaction->terminal_id = session('terminalId');
+                if($transaction->status == 'deleted' || $transaction->posted == true)
+                    $uploaded[] = $transaction->id;
             }
             
+            if(count($uploaded) > 0){
+                Transaction::whereIn('id', $uploaded)
+                    ->update([
+                        'uploaded' => true,
+                    ]);
+            }
+
             $body = [
                 'terminal_signature' => $terminal_signature,
                 'data' => json_encode($transactions->toArray()),
@@ -41,7 +51,7 @@ class SyncTransactions
                         Transaction::where('terminal_coi_number', $value)
                             ->update([
                                 'coi_number' => str_pad($key, 8, '0', STR_PAD_LEFT),
-                                'uploaded' => true,
+                                // 'uploaded' => true,
                             ]);
                     }
                 }


### PR DESCRIPTION
- resync:transactions command, corrects `status` "deleted" from server into "active" when the same transaction is active in offline ecoi.
- make transactions status 'deleted' from dates before today when logging in.
- change `uploaded` to true, when transaction `posted` is true or `status` is "deleted". This transactions will be sync for the last time.